### PR TITLE
Remove unneeded package from requirements

### DIFF
--- a/requirements/requirement.txt
+++ b/requirements/requirement.txt
@@ -41,7 +41,6 @@ odfpy==1.3.6
 olefile==0.45.1
 # moved to repanier.packages : openpyxl==1.8.6, with bug fix on worker.worksheet.py lines 103-106
 openpyxl==2.5.5
-pkg-resources==0.0.0
 psycopg2==2.7.5
 pyaml==17.8.0
 python-dateutil==2.7.3


### PR DESCRIPTION
Hi,
I encountered a bug while installing repanier dependencies. 
The presence of the package `pkg-resources` in `requirement.txt` is the result of a bug from Debian based OS:
https://github.com/pypa/pip/issues/4022
The `pip install -r requirement.txt` failed on my system (Archlinux) due to the related package.
This pull request simply removes the package from the requirements list.